### PR TITLE
Implement plan service and DI configuration

### DIFF
--- a/src/FitnessTracker.API/Controllers/MealPlanController.cs
+++ b/src/FitnessTracker.API/Controllers/MealPlanController.cs
@@ -39,8 +39,9 @@ namespace FitnessTracker.API.Controllers
         public async Task<ActionResult<Plan>> GetPlan()
         {
             var userId = Guid.Parse(User.FindFirst("oid")!.Value);
-            await _planService.GetPlanForUserAsync(userId); // This line is incorrect
-            return Ok(); // Placeholder return to avoid compilation error
+            var plan = await _planService.GetPlanForUserAsync(userId);
+            if (plan is null) return NotFound();
+            return Ok(plan);
         }
 
         [HttpPost("plan")]

--- a/src/FitnessTracker.API/Program.cs
+++ b/src/FitnessTracker.API/Program.cs
@@ -1,9 +1,11 @@
-using FitnessTracker.Infrastructure.Services;
-using FitnessTracker.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Azure.Cosmos;
+using OpenAI;
+using FitnessTracker.API.Data;
+using FitnessTracker.API.Services;
+using FitnessTracker.Infrastructure.Data;
 using FitnessTracker.Infrastructure.Services;
-using FitnessTracker.Infrastructure;      // or the correct namespace for INutritionService
-
+using FitnessTracker.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,10 +15,18 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 builder.Services.AddDbContext<FitnessTrackerDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
-builder.Services.AddScoped<IPlanService, PlanService>();
-// Infrastructure services
+
+builder.Services.AddHttpClient();
+builder.Services.AddSingleton(new CosmosClient(builder.Configuration["Cosmos:ConnectionString"]));
+builder.Services.AddSingleton(new OpenAIClient(builder.Configuration["OpenAI:Key"]));
+
+builder.Services.AddScoped<ICosmosExerciseService, CosmosExerciseService>();
+builder.Services.AddScoped<INutritionAggregatorService, NutritionAggregatorService>();
+builder.Services.AddScoped<IOpenAiMealPlanService, OpenAiMealPlanService>();
 builder.Services.AddScoped<INutritionService, NutritionService>();
 builder.Services.AddScoped<IPlanService, PlanService>();
 

--- a/src/FitnessTracker.Infrastructure/Services/IPlanService.cs
+++ b/src/FitnessTracker.Infrastructure/Services/IPlanService.cs
@@ -5,7 +5,7 @@ namespace FitnessTracker.Infrastructure.Services
     public interface IPlanService
     {
         Task<Plan> GeneratePlanAsync(PlanRequest request);
-        Task GetPlanForUserAsync(Guid userId);
+        Task<Plan?> GetPlanForUserAsync(Guid userId);
         Task SavePlanAsync(Plan plan);
     }
 

--- a/src/FitnessTracker.Infrastructure/Services/PlanService.cs
+++ b/src/FitnessTracker.Infrastructure/Services/PlanService.cs
@@ -17,27 +17,33 @@ namespace FitnessTracker.Infrastructure.Services
             var plan = new Plan
             {
                 PlanId = Guid.NewGuid(),
-                UserId = Guid.Empty,
+                UserId = request.UserId,
                 DailyCalorieTarget = request.Calories
             };
+
             _context.Plans.Add(plan);
             await _context.SaveChangesAsync();
             return plan;
         }
 
-        Task<Plan> IPlanService.GeneratePlanAsync(PlanRequest request)
+        public Task<Plan?> GetPlanForUserAsync(Guid userId)
         {
-            throw new NotImplementedException();
+            return _context.Plans.FirstOrDefaultAsync(p => p.UserId == userId);
         }
 
-        Task IPlanService.GetPlanForUserAsync(Guid userId)
+        public async Task SavePlanAsync(Plan plan)
         {
-            throw new NotImplementedException();
-        }
+            var exists = await _context.Plans.AnyAsync(p => p.PlanId == plan.PlanId);
+            if (exists)
+            {
+                _context.Plans.Update(plan);
+            }
+            else
+            {
+                _context.Plans.Add(plan);
+            }
 
-        Task IPlanService.SavePlanAsync(Plan plan)
-        {
-            throw new NotImplementedException();
+            await _context.SaveChangesAsync();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add DI setup for CosmosDB, OpenAI, ApplicationDbContext and services
- implement `IPlanService` fully with retrieval and save capabilities
- wire up meal plan endpoints to return stored plan

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68783b7f7be0832396cd1493e61bc7d9