### PR TITLE
Fix default user handling for dev environment

### DIFF
--- a/src/FitnessTracker.API/Controllers/MealPlanController.cs
+++ b/src/FitnessTracker.API/Controllers/MealPlanController.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Hosting;
 using FitnessTracker.Core.Models;
 using FitnessTracker.API.Services;
 using FitnessTracker.Infrastructure.Services; // for IPlanService
@@ -15,13 +16,16 @@ namespace FitnessTracker.API.Controllers
     {
         private readonly IOpenAiMealPlanService _mealPlanService;
         private readonly IPlanService _planService;
+        private readonly IWebHostEnvironment _env;
 
         public MealPlanController(
             IOpenAiMealPlanService mealPlanService,
-            IPlanService planService)
+            IPlanService planService,
+            IWebHostEnvironment env)
         {
             _mealPlanService = mealPlanService;
             _planService = planService;
+            _env = env;
         }
 
         private bool TryGetUserId(out Guid userId)
@@ -29,6 +33,11 @@ namespace FitnessTracker.API.Controllers
             var claim = User.FindFirst("oid");
             if (claim != null && Guid.TryParse(claim.Value, out userId))
             {
+                return true;
+            }
+            if (_env.IsDevelopment())
+            {
+                userId = Guid.Parse("00000000-0000-0000-0000-000000000001");
                 return true;
             }
             userId = default;

--- a/src/FitnessTracker.API/Controllers/NutritionController.cs
+++ b/src/FitnessTracker.API/Controllers/NutritionController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Hosting;
 using FitnessTracker.Core.Models;
 using FitnessTracker.Infrastructure.Services;
 
@@ -11,14 +12,24 @@ namespace FitnessTracker.API.Controllers;
 public class NutritionController : ControllerBase
 {
     private readonly INutritionAggregatorService _svc;
+    private readonly IWebHostEnvironment _env;
 
-    public NutritionController(INutritionAggregatorService svc) => _svc = svc;
+    public NutritionController(INutritionAggregatorService svc, IWebHostEnvironment env)
+    {
+        _svc = svc;
+        _env = env;
+    }
 
     private bool TryGetUserId(out Guid userId)
     {
         var claim = User.FindFirst("oid");
         if (claim != null && Guid.TryParse(claim.Value, out userId))
         {
+            return true;
+        }
+        if (_env.IsDevelopment())
+        {
+            userId = Guid.Parse("00000000-0000-0000-0000-000000000001");
             return true;
         }
         userId = default;

--- a/src/FitnessTracker.API/Controllers/WeightController.cs
+++ b/src/FitnessTracker.API/Controllers/WeightController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using FitnessTracker.Core.Models;
 using FitnessTracker.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Hosting;
 
 namespace FitnessTracker.API.Controllers;
 
@@ -12,14 +13,24 @@ namespace FitnessTracker.API.Controllers;
 public class WeightController : ControllerBase
 {
     private readonly FitnessTrackerDbContext _db;
+    private readonly IWebHostEnvironment _env;
 
-    public WeightController(FitnessTrackerDbContext db) => _db = db;
+    public WeightController(FitnessTrackerDbContext db, IWebHostEnvironment env)
+    {
+        _db = db;
+        _env = env;
+    }
 
     private bool TryGetUserId(out Guid userId)
     {
         var claim = User.FindFirst("oid");
         if (claim != null && Guid.TryParse(claim.Value, out userId))
         {
+            return true;
+        }
+        if (_env.IsDevelopment())
+        {
+            userId = Guid.Parse("00000000-0000-0000-0000-000000000001");
             return true;
         }
         userId = default;

--- a/src/FitnessTracker.API/Program.cs
+++ b/src/FitnessTracker.API/Program.cs
@@ -47,9 +47,11 @@ if (builder.Environment.IsDevelopment())
     // Dev: allow EVERYTHING, no JWT key needed
     builder.Services.AddAuthorization(options =>
     {
-        options.FallbackPolicy = new AuthorizationPolicyBuilder()
+        var allowAll = new AuthorizationPolicyBuilder()
             .RequireAssertion(_ => true)
             .Build();
+        options.DefaultPolicy = allowAll;
+        options.FallbackPolicy = allowAll;
     });
 }
 else

--- a/src/FitnessTracker.Infrastructure/FitnessTracker.Infrastructure.csproj
+++ b/src/FitnessTracker.Infrastructure/FitnessTracker.Infrastructure.csproj
@@ -6,13 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.52.0" />


### PR DESCRIPTION
## Summary
- set default and fallback authorization policies in dev
- inject `IWebHostEnvironment` into controllers
- use a fixed user ID when no oid claim exists in development
- remove missing appsettings.json reference from infrastructure project

## Testing
- `dotnet build`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68799dd99bec832383b359059b517336