### PR TITLE
Add unit tests for controllers and services

### DIFF
--- a/tests/FitnessTracker.Tests/FitnessTracker.Tests.csproj
+++ b/tests/FitnessTracker.Tests/FitnessTracker.Tests.csproj
@@ -23,6 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.20" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/tests/FitnessTracker.Tests/MealPlanControllerTests.cs
+++ b/tests/FitnessTracker.Tests/MealPlanControllerTests.cs
@@ -1,0 +1,70 @@
+using FitnessTracker.API.Controllers;
+using FitnessTracker.API.Services;
+using FitnessTracker.Infrastructure.Services;
+using FitnessTracker.Core.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Moq;
+
+namespace FitnessTracker.Tests;
+
+public class MealPlanControllerTests
+{
+    private static MealPlanController CreateController(IOpenAiMealPlanService mealSvc, IPlanService planSvc)
+    {
+        var env = Mock.Of<IWebHostEnvironment>(e => e.EnvironmentName == "Development");
+        var ctrl = new MealPlanController(mealSvc, planSvc, env);
+        var ctx = new DefaultHttpContext();
+        ctx.User = new System.Security.Claims.ClaimsPrincipal(new System.Security.Claims.ClaimsIdentity());
+        ctrl.ControllerContext.HttpContext = ctx;
+        return ctrl;
+    }
+
+    [Fact]
+    public async Task Generate_returns_plan_from_service()
+    {
+        var plan = new MealPlan { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), TotalCalories = 1000, PlanJson = "{}" };
+        var mealSvc = new Mock<IOpenAiMealPlanService>();
+        mealSvc.Setup(s => s.GenerateDailyMealPlanAsync(1000, It.IsAny<Guid>()))
+               .ReturnsAsync(plan);
+        var ctrl = CreateController(mealSvc.Object, Mock.Of<IPlanService>());
+
+        var result = await ctrl.Generate(1000);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal(plan, ok.Value);
+    }
+
+    [Fact]
+    public async Task GetPlan_returns_NotFound_when_null()
+    {
+        var planSvc = new Mock<IPlanService>();
+        planSvc.Setup(s => s.GetPlanForUserAsync(It.IsAny<Guid>()))
+                .ReturnsAsync((Plan?)null);
+        var ctrl = CreateController(Mock.Of<IOpenAiMealPlanService>(), planSvc.Object);
+
+        var result = await ctrl.GetPlan();
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task SavePlan_passes_user_to_service()
+    {
+        var planSvc = new Mock<IPlanService>();
+        Plan? saved = null;
+        planSvc.Setup(s => s.SavePlanAsync(It.IsAny<Plan>()))
+                .Callback<Plan>(p => saved = p)
+                .Returns(Task.CompletedTask);
+        var ctrl = CreateController(Mock.Of<IOpenAiMealPlanService>(), planSvc.Object);
+
+        var input = new Plan { DailyCalorieTarget = 1500 };
+        var resp = await ctrl.SavePlan(input);
+
+        Assert.IsType<NoContentResult>(resp);
+        Assert.NotNull(saved);
+        Assert.Equal(input.DailyCalorieTarget, saved!.DailyCalorieTarget);
+        Assert.NotEqual(Guid.Empty, saved.UserId);
+    }
+}

--- a/tests/FitnessTracker.Tests/PlanServiceTests.cs
+++ b/tests/FitnessTracker.Tests/PlanServiceTests.cs
@@ -1,0 +1,48 @@
+using FitnessTracker.Core.Models;
+using FitnessTracker.Infrastructure.Data;
+using FitnessTracker.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace FitnessTracker.Tests;
+
+public class PlanServiceTests
+{
+    private static FitnessTrackerDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<FitnessTrackerDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new FitnessTrackerDbContext(options);
+    }
+
+    [Fact]
+    public async Task GeneratePlan_creates_and_saves_plan()
+    {
+        using var db = CreateDb();
+        var svc = new PlanService(db);
+        var req = new PlanRequest { Calories = 2000, UserId = Guid.NewGuid() };
+
+        var plan = await svc.GeneratePlanAsync(req);
+
+        Assert.NotEqual(Guid.Empty, plan.PlanId);
+        Assert.Equal(req.UserId, plan.UserId);
+        Assert.Equal(req.Calories, plan.DailyCalorieTarget);
+        Assert.Equal(1, await db.Plans.CountAsync());
+    }
+
+    [Fact]
+    public async Task SavePlan_updates_existing()
+    {
+        using var db = CreateDb();
+        var svc = new PlanService(db);
+        var plan = new Plan { PlanId = Guid.NewGuid(), UserId = Guid.NewGuid(), DailyCalorieTarget = 1500 };
+        db.Plans.Add(plan);
+        await db.SaveChangesAsync();
+
+        plan.DailyCalorieTarget = 1800;
+        await svc.SavePlanAsync(plan);
+
+        var fromDb = await db.Plans.FirstAsync();
+        Assert.Equal(1800, fromDb.DailyCalorieTarget);
+    }
+}

--- a/tests/FitnessTracker.Tests/WeightControllerTests.cs
+++ b/tests/FitnessTracker.Tests/WeightControllerTests.cs
@@ -1,0 +1,62 @@
+using Moq;
+using FitnessTracker.API.Controllers;
+using FitnessTracker.Core.Models;
+using FitnessTracker.Infrastructure.Data;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Http;
+
+namespace FitnessTracker.Tests;
+
+public class WeightControllerTests
+{
+    private static WeightController CreateController(FitnessTrackerDbContext ctx)
+    {
+        var env = Mock.Of<IWebHostEnvironment>(e => e.EnvironmentName == "Development");
+        var ctrl = new WeightController(ctx, env);
+        ctrl.ControllerContext.HttpContext = new DefaultHttpContext
+        {
+            User = new System.Security.Claims.ClaimsPrincipal(new System.Security.Claims.ClaimsIdentity())
+        };
+        return ctrl;
+    }
+
+    private static FitnessTrackerDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<FitnessTrackerDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new FitnessTrackerDbContext(options);
+    }
+
+    [Fact]
+    public async Task Post_saves_entry()
+    {
+        using var db = CreateDb();
+        var ctrl = CreateController(db);
+        var entry = new WeightEntry { WeightKg = 80 };
+
+        var result = await ctrl.Post(entry);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var saved = await db.WeightEntries.FirstAsync();
+        Assert.Equal(saved.Id, ((WeightEntry)ok.Value!).Id);
+    }
+
+    [Fact]
+    public async Task GetAll_returns_user_entries()
+    {
+        using var db = CreateDb();
+        db.WeightEntries.Add(new WeightEntry { Id = Guid.NewGuid(), UserId = Guid.Parse("00000000-0000-0000-0000-000000000001"), Date = DateTime.UtcNow, WeightKg = 70 });
+        db.WeightEntries.Add(new WeightEntry { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), Date = DateTime.UtcNow, WeightKg = 90 });
+        await db.SaveChangesAsync();
+        var ctrl = CreateController(db);
+
+        var result = await ctrl.GetAll();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var list = Assert.IsAssignableFrom<IEnumerable<WeightEntry>>(ok.Value);
+        Assert.Single(list);
+    }
+}


### PR DESCRIPTION
## Summary
- add new unit tests for PlanService
- add MealPlanController and WeightController tests using mocks
- include EFCore InMemory provider for tests

## Testing
- `dotnet build tests/FitnessTracker.Tests/FitnessTracker.Tests.csproj --no-restore --verbosity minimal`
- `dotnet test tests/FitnessTracker.Tests/FitnessTracker.Tests.csproj --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_6879c0e56b548323a065b03121aa3acd