### PR TITLE
Fix base address for emulator

### DIFF
--- a/FitnessTracker.Mobile/MauiProgram.cs
+++ b/FitnessTracker.Mobile/MauiProgram.cs
@@ -18,7 +18,14 @@ public static class MauiProgram
 
         builder.Services.AddHttpClient<ApiService>(client =>
         {
-            client.BaseAddress = new Uri("https://localhost:5001/");
+#if ANDROID
+            // When running on an Android emulator, use the host machine
+            // address `10.0.2.2` to reach the local API running under IIS
+            // Express on https://localhost:44363.
+            client.BaseAddress = new Uri("https://10.0.2.2:44363/");
+#else
+            client.BaseAddress = new Uri("https://localhost:44363/");
+#endif
         });
 
         return builder.Build();


### PR DESCRIPTION
## Summary
- configure the MAUI client to use the `10.0.2.2` host when running on Android emulators
- default to the IIS Express port 44363 when not on Android

## Testing
- `dotnet test tests/FitnessTracker.Tests/FitnessTracker.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687e7d682ad0832398c4a2333124244c